### PR TITLE
updated script to configure passwd length and account lockout

### DIFF
--- a/packer/scripts/001-critical-standards.sh
+++ b/packer/scripts/001-critical-standards.sh
@@ -149,12 +149,72 @@ configure_firewall() {
   
 }
 
+password_length() {
+  log "configuring minimum password length"
+  config_file="/etc/security/pwquality.conf"
+  echo "$config_file"
+  # Check if it is a Debian system
+  if [ -f /etc/debian_version ]; then
+    #check if  libpam-pwquality is installed
+    if dpkg -s libpam-pwquality &>/dev/null; then
+      sed -i 's/^\s*#\?\s*minlen\s*=\s*[0-9]\+/minlen=12/' "$config_file"
+    else
+      apt update && apt install -y libpam-pwquality
+      sed -i 's/^\s*#\?\s*minlen\s*=\s*[0-9]\+/minlen=12/' "$config_file"
+    fi
+    
+   # Check if it is a Red Hat system
+  elif [ -f /etc/redhat-release ]; then
+    # Update the minlen value to 12
+    sed -i 's/^\s*#\?\s*minlen\s*=\s*[0-9]\+/minlen=12/' "$config_file"
+  fi
+  
+  # Capture the exit code
+  exit_code=$?
+  # Return the exit code
+  return $exit_code  
+}
+
+# Function to enforce account lockout policy
+enforce_account_lockout() {
+  # Check if the system is Debian-based
+  if [ -f /etc/debian_version ]; then
+    # Update /etc/pam.d/common-auth to lock accounts after 5 failed attempts
+    echo "auth required pam_tally2.so deny=5 unlock_time=900" >> /etc/pam.d/common-auth
+  elif [ -f /etc/redhat-release ]; then
+    # Update /etc/pam.d/system-auth to lock accounts after 5 failed attempts
+    echo "auth required pam_tally2.so deny=5 unlock_time=900" >> /etc/pam.d/system-auth
+  fi
+  # Capture the exit code
+  exit_code=$?
+  # Return the exit code
+  return $exit_code
+}
+
+
 # Main execution
 disable_services
 install_tools_and_update
 setup_log_directory
 secure_ssh
 configure_firewall
+
+password_length
+# Check the exit code of the previous function
+if [ $? -ne 0 ]; then
+  # Log the error and exit if the function failed
+  echo "Failed to enforce minimum password length. Exiting..."
+  exit 1
+fi
+
+enforce_account_lockout
+# Check the exit code of the previous function
+if [ $? -ne 0 ]; then
+  # Log the error and exit if the function failed
+  echo "Failed to enforce account lockout policy. Exiting..."
+  exit 1
+fi
+
 clean_temp_files
 
 log "001-critical-standards.sh completed successfully."


### PR DESCRIPTION
This pull request covers the requirement for TDP-247, update the script to enforce minimum password length and enforce account lockout 
![after_passwd_len_debian](https://github.com/user-attachments/assets/8ad4a7ae-847e-42ac-9c44-046377bae4c0)
![b4-passwordlength_debian](https://github.com/user-attachments/assets/694dd795-bf6c-4fc4-be92-87eb8bab8b4b)
![after_lockout_debian](https://github.com/user-attachments/assets/1b85a199-4272-47cd-b19b-0190e2d6af8e)
![after_lockout_redhat](https://github.com/user-attachments/assets/48fed67a-60ad-4328-a4d1-9c23a4107ed4)

